### PR TITLE
Coverage fails with wrong number of lines

### DIFF
--- a/src/main/java/org/sonar/plugins/cobertura/CoberturaReportParser.java
+++ b/src/main/java/org/sonar/plugins/cobertura/CoberturaReportParser.java
@@ -89,9 +89,15 @@ public class CoberturaReportParser {
         InputFile resource = javaResourceLocator.findResourceByClassName(className);
         if (resourceExists(resource)) {
           for (Measure measure : entry.getValue().createMeasures()) {
-            Serializable value = ValueType.DATA.equals(measure.getMetric().getType()) ? measure.getData() : measure.value();
-            LOGGER.debug("new measure for metric {} on {}: {}",new Object[] {measure.getMetric(), resource, value});
-            context.newMeasure().forMetric(measure.getMetric()).on(resource).withValue(value).save();
+			try{
+				Serializable value = ValueType.DATA.equals(measure.getMetric().getType()) ? measure.getData() : measure.value();
+				LOGGER.debug("new measure for metric {} on {}: {}",new Object[] {measure.getMetric(), resource, value});
+				context.newMeasure().forMetric(measure.getMetric()).on(resource).withValue(value).save();
+			} catch (Exception e) {
+				String bad_input = e.getMessage();
+				System.out.println("Bad input: " + bad_input);
+				continue;
+			}
           }
         }
       }

--- a/src/main/java/org/sonar/plugins/cobertura/CoberturaReportParser.java
+++ b/src/main/java/org/sonar/plugins/cobertura/CoberturaReportParser.java
@@ -93,10 +93,9 @@ public class CoberturaReportParser {
 				Serializable value = ValueType.DATA.equals(measure.getMetric().getType()) ? measure.getData() : measure.value();
 				LOGGER.debug("new measure for metric {} on {}: {}",new Object[] {measure.getMetric(), resource, value});
 				context.newMeasure().forMetric(measure.getMetric()).on(resource).withValue(value).save();
-			} catch (Exception e) {
-				String bad_input = e.getMessage();
-				System.out.println("Bad input: " + bad_input);
-				continue;
+			} catch (Exception e) {				
+				LOGGER.warn("Bad input: "+e.getMessage());
+	            continue;			
 			}
           }
         }


### PR DESCRIPTION
Hi Geoffrey
We are facing this issue only with the functional code coverage. This scenario happens very frequently in case of functional code coverage If there is a difference in the line numbers in the coverage(xml) and the original file then the analysis is failing with the following exception  :
**Error during Sonar runner execution
org.sonar.runner.impl.RunnerException: Unable to execute Sonar
	at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:91)
	at org.sonar.runner.impl.BatchLauncher$1.run(BatchLauncher.java:75)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.sonar.runner.impl.BatchLauncher.doExecute(BatchLauncher.java:69)
	at org.sonar.runner.impl.BatchLauncher.execute(BatchLauncher.java:50)
	at org.sonar.runner.api.EmbeddedRunner.doExecute(EmbeddedRunner.java:102)
	at org.sonar.runner.api.Runner.execute(Runner.java:100)
	at org.sonar.runner.Main.executeTask(Main.java:70)
	at org.sonar.runner.Main.execute(Main.java:59)
	at org.sonar.runner.Main.main(Main.java:53)
Caused by: java.lang.IllegalStateException: Can't create measure for line 173 for file '/jenkins/workspace/Coverage/FunctionalCodeCoverage/ConsolidatedFunctionalCodeCoverage/src/com/in/co/csp/cso/ims/reports/action/IMSReportsGeneralTabAction.java' with 169 lines**

We think sonar analysis should not  fail in case of functional code coverage even if there are some mismatch of line numbers for some file.

